### PR TITLE
Improve state sync after UI control

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 > 2. TCP端口默认为`9999`
 > 3. 用户名默认为`admin`
 > 4. 密码默认为空
+> 5. 从UI控制设备后会立即主动拉取一次最新状态
 
 # Credits
 [xswxm/home-assistant-zhong-hong](https://github.com/xswxm/home-assistant-zhong-hong)


### PR DESCRIPTION
## Summary
- refresh state immediately after executing a command
- mention refresh behaviour in README

## Testing
- `python -m py_compile custom_components/zhong_hong_vrf/climate.py`
- `flake8 custom_components/zhong_hong_vrf/climate.py`

------
https://chatgpt.com/codex/tasks/task_e_688229eeac908327b56865e19ad8c318