### PR TITLE
Handle gateway disconnections and use HA brand

### DIFF
--- a/custom_components/zhong_hong_vrf/client.py
+++ b/custom_components/zhong_hong_vrf/client.py
@@ -45,6 +45,9 @@ class ZhongHongClient:
         # Version tracking for device state
         self._version_counter = 0
 
+        # Track connection status for availability
+        self._tcp_connected = True
+
         self.devices: Dict[str, Dict[str, Any]] = {}
         self.device_info: Dict[str, str] = {}
 
@@ -112,13 +115,24 @@ class ZhongHongClient:
             except Exception as ex:
                 _LOGGER.error("Error in update callback: %s", ex)
 
+    @property
+    def is_tcp_connected(self) -> bool:
+        """Return TCP connection state."""
+        return self._tcp_connected
+
     async def _async_get(self, url: str) -> Optional[Dict[str, Any]]:
         """Make HTTP/0.9 GET request using raw socket for compatibility."""
         try:
             return await self._async_get_http09(url)
+        except asyncio.TimeoutError:
+            _LOGGER.error("HTTP/0.9 request timeout")
+            return None
+        except OSError as ex:
+            _LOGGER.error("HTTP/0.9 socket error: %s", ex)
+            raise ConnectionError from ex
         except Exception as ex:
             _LOGGER.error("HTTP/0.9 request failed: %s", ex)
-            return None
+            raise ConnectionError from ex
 
     async def _async_get_http09(self, url: str) -> Optional[Dict[str, Any]]:
         """Use raw socket for HTTP/0.9 requests."""
@@ -136,6 +150,7 @@ class ZhongHongClient:
             path,
         )
 
+        writer = None
         try:
             # Create socket connection
             reader, writer = await asyncio.wait_for(
@@ -170,9 +185,6 @@ class ZhongHongClient:
                     break
                 response_data += chunk
 
-            writer.close()
-            await writer.wait_closed()
-
             # Parse response (skip HTTP headers)
             response_text = response_data.decode("utf-8", errors="ignore")
 
@@ -192,13 +204,13 @@ class ZhongHongClient:
             result = json.loads(json_str)
             _LOGGER.debug("Successfully parsed HTTP/0.9 response: %s", result)
             return result
-
-        except asyncio.TimeoutError:
-            _LOGGER.error("HTTP/0.9 request timeout")
-            return None
-        except Exception as ex:
-            _LOGGER.error("HTTP/0.9 socket error: %s", ex)
-            return None
+        finally:
+            if writer is not None:
+                writer.close()
+                try:
+                    await writer.wait_closed()
+                except Exception:  # pragma: no cover - best effort
+                    pass
 
 
     async def async_get_devices(self) -> List[Dict[str, Any]]:
@@ -327,7 +339,12 @@ class ZhongHongClient:
             fan,
         )
 
-        response = await self._async_get(url)
+        try:
+            response = await self._async_get(url)
+        except ConnectionError as ex:
+            _LOGGER.error("Control request failed: %s", ex)
+            return False
+
         success = response is not None and response.get("err") == 0
 
         _LOGGER.debug("Cmd result: success=%s, response=%s", success, response)
@@ -348,6 +365,7 @@ class ZhongHongClient:
     def stop_tcp_listener(self) -> None:
         """Stop TCP socket listener."""
         self._listening = False
+        self._tcp_connected = False
         if self._tcp_socket:
             self._tcp_socket.close()
             self._tcp_socket = None
@@ -387,8 +405,10 @@ class ZhongHongClient:
                     _LOGGER.info(
                         "TCP connected to %s:%s", self.host, self.port
                     )
+                    self._tcp_connected = True
                 except Exception as connect_ex:
                     _LOGGER.error("TCP connect failed: %s", connect_ex)
+                    self._tcp_connected = False
                     time.sleep(5)
                     continue
 
@@ -462,10 +482,12 @@ class ZhongHongClient:
                 continue
             except socket.error as sock_ex:
                 _LOGGER.error("TCP socket error: %s", sock_ex)
+                self._tcp_connected = False
                 if self._tcp_socket:
                     self._tcp_socket.close()
                     self._tcp_socket = None
                 time.sleep(5)
             except Exception as ex:
                 _LOGGER.error("TCP listener error: %s", ex)
+                self._tcp_connected = False
                 time.sleep(5)

--- a/custom_components/zhong_hong_vrf/climate.py
+++ b/custom_components/zhong_hong_vrf/climate.py
@@ -113,6 +113,11 @@ class ZhongHongClimate(CoordinatorEntity, ClimateEntity):
         self.coordinator.unregister_device_callback(self._handle_device_update)
         await super().async_will_remove_from_hass()
 
+    @property
+    def available(self) -> bool:  # type: ignore[override]
+        """Entity availability based on coordinator and TCP connection."""
+        return super().available and self.coordinator.client.is_tcp_connected
+
     def _update_device_data(
         self,
         device_data: dict[str, Any],

--- a/custom_components/zhong_hong_vrf/manifest.json
+++ b/custom_components/zhong_hong_vrf/manifest.json
@@ -8,6 +8,7 @@
   "codeowners": ["@Johnnybyzhang"],
   "config_flow": true,
   "iot_class": "local_push",
+  "brand": "zhong_hong",
   "supported_brands": {
     "zhong_hong": "Zhong Hong"
   }


### PR DESCRIPTION
## Summary
- Mark climate entities unavailable when TCP gateway disconnects or HTTP requests fail
- Use Zhong Hong brand assets from Home Assistant core

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6896d6b9c188832785cfc9e4fc0aa2a1